### PR TITLE
Fix: Add missing School Pride activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "School Pride": {
+        "description": "Show your Mergington spirit! Plan pep rallies, paint banners, and boost school morale",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixes issue #2 by adding the missing "School Pride" activity to the extracurricular activities list.

## Changes
- Added "School Pride" activity to the activities dictionary in `src/app.py`
- Activity includes:
  - Description: "Show your Mergington spirit! Plan pep rallies, paint banners, and boost school morale"
  - Schedule: Wednesdays, 3:30 PM - 4:30 PM
  - Max participants: 25 students
  - Empty participants list (ready for signups)

## Testing
- ✅ Activity follows the same structure as existing activities
- ✅ Can be displayed in the activities list
- ✅ Supports signup and unregister functionality

Fixes #2